### PR TITLE
Remove trailing newlines

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ fs.readFile(process.env.PWD + "/" + process.argv[2], function(err, data) {
     if (err) {
         console.log(err);
     } else {
-        var x = data.toString().split('\n').map(JSON.parse);
+        var x = data.toString().trim().split('\n').map(JSON.parse);
         process.stdout.write(JSON.stringify(x));
     }
 });


### PR DESCRIPTION
If you got trailing newlines in your NDJSON-file, they will fail JSON.parse(..).

Try for example this file: http://folk.uio.no/mikaello/test.json

```
wget http://folk.uio.no/mikaello/test.json
npx ndjson-to-json test.json
```
This will print error:
```
$ npx ndjson-to-json test.json 
npx: installed 1 in 1.502s
undefined:1

SyntaxError: Unexpected end of JSON input
    at parse (<anonymous>)
    at Array.map (<anonymous>)
    at /Users/mikaeo/.npm/_npx/58427/lib/node_modules/ndjson-to-json/index.js:7:45
    at FSReqCallback.readFileAfterClose [as oncomplete] (internal/fs/read_file_context.js:53:3)
```

While this fix will remove the newline and parsing will work.