### PR TITLE
docs(*): add tip on using this package with npx

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,13 @@ Its also the download format that is used in Google Big Query.
 http://ndjson.org
 
 # Installation
-npm install -g ndjson-to-json
+`npm install -g ndjson-to-json`
 
 # Usage
-ndjson-to-json file.json
+`ndjson-to-json file.json`
+
+Or use with npx without installing it on beforehand:
+`npx ndjson-to-json file.json`
 
 # Example
 Github Licenses downloaded from Google BigQuery in NDJSON format


### PR DESCRIPTION
I guess many would use this tool only once or a few times, so installing it globally would be a bit overkill. So here is a suggestion to use `npx` instead of installing it.